### PR TITLE
Hapara Bypass

### DIFF
--- a/HaparaBypass-Iframe.html
+++ b/HaparaBypass-Iframe.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+ 
+<head>
+   <title>Hapara Bypass</title>
+   <style type="text/css">
+       html {
+           overflow: auto;
+       }
+         
+       html,
+       body,
+       div,
+       iframe {
+           margin: 0px;
+           padding: 0px;
+           height: 100%;
+           border: none;
+       }
+         
+       iframe {
+           display: block;
+           width: 100%;
+           border: none;
+           overflow-y: auto;
+           overflow-x: hidden;
+       }
+   </style>
+</head>
+<body>
+   <iframe src="https://www.google.com.au"
+           frameborder="0"
+           marginheight="0"
+           marginwidth="0"
+           width="100%"
+           height="100%"
+           scrolling="auto"
+id="google">
+ </iframe>
+</body>
+ 
+</html> 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ An exploit that allows for access to sites outside of the Hapara Focus Session
 **YOU MUST NEED data: LINKS ALLOWED, IF YOU DON'T HAVE THOSE ALLOWED, THIS WILL NOT WORK**.
 
 1. create a bookmark named anything, head to the URL section, and paste this in it: `data:text/html,<!DOCTYPE html> <html> <head> <title>full screen iframe</title> <style type="text/css"> html { overflow: auto; } html, body, div, iframe { margin: 0px; padding: 0px; height: 100%; border: none; } iframe { display: block; width: 100%; border: none; overflow-y: auto; overflow-x: hidden; } </style> </head> <body> <iframe src="https://www.google.com.au" frameborder="0" marginheight="0" marginwidth="0" width="100%" height="100%" scrolling="auto" id="google"> </iframe> </body> </html>`
-2.  when you are in a focus session, click the bookmark, and it will open a google tab. (If it says that it doesn't work, then you can download the [Iframe](url)
+2.  when you are in a focus session, click the bookmark, and it will open a google tab. (If it says that it doesn't work, then you can download the [Iframe](https://github.com/3kh0/ext-remover/blob/main/HaparaBypass-Iframe.html)
+3.  enjoy not having to listen to a lecture from your teacher!
+(Credit to [Hero Link 6](https://github.com/HeroLink6) For finding this exploit, you can find more info on his GitHub repository [here](https://github.com/HeroLink6/Hapara-Focus-Session-Bypass/tree/main).)
 
 ## GuardianTabCrash *Unrestricted browsing*
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Thank you to all of the contributors! Yall really are pretty epic :D
 <a href="https://github.com/3kh0/ext-remover/graphs/contributors"><img src="https://contrib.rocks/image?repo=3kh0/ext-remover" /></a>
 
 - [EXT-REMOVER](#ext-remover)
+  * [Hapara Focus Session Bypass](#hapara-focus-session-bypass)
   * [GuardianTabCrash *Unrestricted browsing*](#guardiantabcrash-unrestricted-browsing)
   * [Skiovox *Unrestricted browsing*](#skiovox-unrestricted-browsing)
   * [LTBEEF *Disable extensions*](#ltbeef-disable-extensions)
@@ -47,6 +48,21 @@ Thank you to all of the contributors! Yall really are pretty epic :D
   * [Microsoft Labs](#microsoft-labs-virtualbox-but-it-got-20-doses-of-the-covid-vaccine*)
 
 <small><i><a href='http://github.com/3kh0/readme-toc/'>Table of contents generated with readme-toc</a></i></small>
+
+## Hapara Focus Session Bypass
+
+### What is it?
+
+An exploit that allows for access to sites outside of the Hapara Focus Session
+
+### How to use it?
+
+**You teacher may be able to still see your screen, but they won't think you are doing anything wrong because of the focus session.**
+
+**YOU MUST NEED data: LINKS ALLOWED, IF YOU DON'T HAVE THOSE ALLOWED, THIS WILL NOT WORK**.
+
+1. create a bookmark named anything, head to the URL section, and paste this in it: `data:text/html,<!DOCTYPE html> <html> <head> <title>full screen iframe</title> <style type="text/css"> html { overflow: auto; } html, body, div, iframe { margin: 0px; padding: 0px; height: 100%; border: none; } iframe { display: block; width: 100%; border: none; overflow-y: auto; overflow-x: hidden; } </style> </head> <body> <iframe src="https://www.google.com.au" frameborder="0" marginheight="0" marginwidth="0" width="100%" height="100%" scrolling="auto" id="google"> </iframe> </body> </html>`
+2.  when you are in a focus session, click the bookmark, and it will open a google tab. (If it says that it doesn't work, then you can download the [Iframe](url)
 
 ## GuardianTabCrash *Unrestricted browsing*
 


### PR DESCRIPTION
I added a new Hapara Exploit, that uses data: links, to create a Google Iframe, and Hapara doesn't check those, so it is an actual way to bypass Hapara Focus Sessions. (Hope that this helps you out!)